### PR TITLE
fix: publish-pact-files should req application_name

### DIFF
--- a/publish-pact-files/publishPactfiles.sh
+++ b/publish-pact-files/publishPactfiles.sh
@@ -3,7 +3,6 @@
 MISSING=()
 [ ! "$PACT_BROKER_BASE_URL" ] && MISSING+=("PACT_BROKER_BASE_URL")
 [ ! "$PACT_BROKER_TOKEN" ] && MISSING+=("PACT_BROKER_TOKEN")
-[ ! "$application_name" ] && MISSING+=("application_name")
 [ ! "$version" ] && MISSING+=("version")
 [ ! "$pactfiles" ] && MISSING+=("pactfiles")
 
@@ -18,7 +17,6 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 echo """
 PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
 PACT_BROKER_TOKEN: $PACT_BROKER_TOKEN
-application_name: $application_name
 version: $version
 pactfiles: $pactfiles
 branch: $branch


### PR DESCRIPTION
Need to update docs.

`application_name` isn't required for this action, and is picked up from the consumer/provider pair in the pact files