### PR TITLE
fix #43: Support setting the OAS content type in publish provider contract action

### DIFF
--- a/publish-provider-contract/README.md
+++ b/publish-provider-contract/README.md
@@ -30,6 +30,7 @@ jobs:
         uses: pactflow/actions/publish-provider-contract@v1.2.0
         env:
           oas_file: src/oas/user.yml
+          oas_file_content_type: application/yml # optional, defaults to application/yaml
           results_file: src/results/report.md
       - name: Publish provider contract on failing test run
         # ensure we publish results even if the tests fail
@@ -44,6 +45,6 @@ jobs:
 
 ## Notes
 
-- If you change your `application_name` you willl need to inform your consumers (their pact tests rely on the name you use here).
-- Assumes 'success = true' (you can control this action by depending on an earliler successful test job).
+- If you change your `application_name` you will need to inform your consumers (their pact tests rely on the name you use here).
+- Assumes 'success = true' (you can control this action by depending on an earlier successful test job).
 - You must ensure `additionalProperties` in your OAS is set to `false` on any response body, to ensure a consumer won't get false positives if they add a new field that isn't actually part of the spec.

--- a/publish-provider-contract/action.yml
+++ b/publish-provider-contract/action.yml
@@ -16,6 +16,9 @@ inputs:
   oas_file:
     description: "Location of the OAS file"
     required: true
+  oas_file_content_type:
+    description: "Content type of the OAS file (optional, default 'application/yaml')"
+    required: false
   results_file:
     description: "Location of the test evidence file"
     required: true

--- a/publish-provider-contract/publishOAS.sh
+++ b/publish-provider-contract/publishOAS.sh
@@ -19,11 +19,13 @@ REPORT_FILE_CONTENT_TYPE=${REPORT_FILE_CONTENT_TYPE:-'text/plain'}
 VERIFIER_TOOL=${VERIFIER_TOOL:-'github-actions'}
 BRANCH=${GITHUB_REF#refs/heads/}
 BUILD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+oas_file_content_type=${oas_file_content_type:-'application/yaml'}
 
 echo """
 URL: $URL
 PACT_BROKER_TOKEN : $PACT_BROKER_TOKEN
 oas_file: $oas_file
+oas_file_content_type: $oas_file_content_type
 results_file: $results_file
 EXIT_CODE: $EXIT_CODE
 BRANCH: $BRANCH
@@ -41,7 +43,7 @@ docker run --rm \
   --provider $application_name \
   --provider-app-version $version \
   --branch $BRANCH \
-  --content-type application/yaml \
+  --content-type $oas_file_content_type \
   --verification-exit-code=$EXIT_CODE \
   --verification-results $results_file \
   --verification-results-content-type $REPORT_FILE_CONTENT_TYPE \


### PR DESCRIPTION
Add optional input for publish-provider-contract action which allows you override the OAS file content-type

---

Can be improved by autodetecting mime-type but since that isn't as simple as `file -b --mime-type <file>` (this doesn't recognise YAML for example) I opted for just a basic override for now.