### PR TITLE
Allow optional inputs for can-i-deploy action

### DIFF
--- a/can-i-deploy/README.md
+++ b/can-i-deploy/README.md
@@ -20,12 +20,12 @@ jobs:
       - uses: pactflow/actions/can-i-deploy@v1.2.0
         env:
           version: "1.0.1" # The pacticipant/application version.
-          to_environment: "environment_name" # The environment into which the pacticipant(s) are to be
-                deployed
+          to_environment: "environment_name" # The environment into which the pacticipant(s) are to be deployed
           # to: "tag_name" # The tag that represents the branch or environment of the integrated applications for which you want to check the verification result status.
-
+          # retry_while_unknown: 5 # Optional: number of times to retry while the verification status is unknown
+          # retry_interval: 10 # Optional: number of seconds to wait between retries
 ```
 
 Set only 1 of `to_environment` or `to` depending on whether you are targeting your deployment location using `environments`(recommended) or `tags`
 
-Read more about migrating from tags to branchs [here](https://docs.pact.io/pact_broker/branches#migrating-from-tags-to-branches)
+Read more about migrating from tags to branches [here](https://docs.pact.io/pact_broker/branches#migrating-from-tags-to-branches)

--- a/can-i-deploy/action.yml
+++ b/can-i-deploy/action.yml
@@ -22,6 +22,16 @@ inputs:
   to:
     description: "The tag you wish to deploy to (test / stage / prod etc...)"
     required: true
+  retry_while_unknown:
+    description: |
+      Optional (default 0): the number of times to retry while there is an unknown
+      verification result (ie. the provider verification is likely still running)
+    required: false
+  retry_interval:
+    description: |
+      Optional (default 10): The time between retries in seconds.
+      Use in conjunction with --retry-while-unknown
+    required: false
 runs:
   using: "composite"
   steps:

--- a/can-i-deploy/canideployTo.sh
+++ b/can-i-deploy/canideployTo.sh
@@ -37,14 +37,29 @@ else
   exit 1
 fi
 
-echo $COMMAND
+OPTIONS=()
+if [ "$retry_while_unknown" ]; then
+  case $retry_while_unknown in
+      ''|*[!0-9]*) echo 'retry_while_unknown has to be an integer' && exit 1 ;;
+      *) OPTIONS+=("--retry-while-unknown $retry_while_unknown") ;;
+  esac
+
+  if [ "$retry_interval" ]; then
+    case $retry_interval in
+        ''|*[!0-9]*) echo 'retry_interval has to be an integer' && exit 1 ;;
+        *) OPTIONS+=("--retry-interval $retry_interval") ;;
+    esac
+  fi
+fi
 
 echo "
   PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
   PACT_BROKER_TOKEN: '$PACT_BROKER_TOKEN'
   application_name: '$application_name'
   VERSION: '$VERSION'
-  to: $to"
+  to: '$to'
+  COMMAND: '$COMMAND'
+  OPTIONS: '${OPTIONS[*]}'"
 
 docker run --rm \
   -e PACT_BROKER_BASE_URL=$PACT_BROKER_BASE_URL \
@@ -53,4 +68,5 @@ docker run --rm \
   broker can-i-deploy \
   --pacticipant "$application_name" \
   $VERSION \
-  $COMMAND
+  $COMMAND \
+  ${OPTIONS[*]}

--- a/can-i-deploy/test/unit/canideployTo.js
+++ b/can-i-deploy/test/unit/canideployTo.js
@@ -84,4 +84,48 @@ describe("canideployTo", () => {
 
     assert.strictEqual(result.status, 0);
   });
+
+  describe("optional variables", () => {
+    it("sets retry_while_unknown and retry_interval", () => {
+      const result = spawnScript({
+        ...mandatoryVars,
+        retry_while_unknown: 5,
+        retry_interval: 10,
+      });
+
+      assert.match(result.stdout.toString(), /can-i-deploy.* --retry-while-unknown 5 --retry-interval 10/);
+      assert.strictEqual(result.status, 0);
+    });
+
+    it("fails when retry_while_unknown is not an integer", () => {
+      const result = spawnScript({
+        ...mandatoryVars,
+        retry_while_unknown: "foo",
+      });
+
+      assert.match(result.stdout.toString(), /retry_while_unknown has to be an integer/);
+      assert.strictEqual(result.status, 1);
+    });
+
+    it("fails when retry_interval is not an integer", () => {
+      const result = spawnScript({
+        ...mandatoryVars,
+        retry_while_unknown: 5,
+        retry_interval: "foo",
+      });
+
+      assert.match(result.stdout.toString(), /retry_interval has to be an integer/);
+      assert.strictEqual(result.status, 1);
+    });
+
+    it("does not set retry_interval when retry_while_unknown is not set", () => {
+      const result = spawnScript({
+        ...mandatoryVars,
+        retry_interval: 10,
+      });
+
+      assert.doesNotMatch(result.stdout.toString(), /--retry-interval/);
+      assert.strictEqual(result.status, 0);
+    });
+  });
 });


### PR DESCRIPTION
- add retry_while_unknown and retry_interval to can-i-deploy command
- add some validation and unit tests
- update the README.md with example usage

See documentation here: https://docs.pact.io/pact_broker/client_cli/readme#can-i-deploy