### PR TITLE
Replace github.action_path to GITHUB_ACTION_PATH

### DIFF
--- a/can-i-deploy/action.yml
+++ b/can-i-deploy/action.yml
@@ -43,7 +43,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/canideployTo.sh
+    - run: ${GITHUB_ACTION_PATH}/canideployTo.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/create-or-update-version/action.yml
+++ b/create-or-update-version/action.yml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/createOrUpdateVersion.sh
+    - run: ${GITHUB_ACTION_PATH}/createOrUpdateVersion.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/create-version-tag/action.yml
+++ b/create-version-tag/action.yml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/createTag.sh
+    - run: ${GITHUB_ACTION_PATH}/createTag.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/delete-branch/action.yml
+++ b/delete-branch/action.yml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/deleteBranch.sh
+    - run: ${GITHUB_ACTION_PATH}/deleteBranch.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/publish-pact-files/action.yml
+++ b/publish-pact-files/action.yml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/publishPactfiles.sh
+    - run: ${GITHUB_ACTION_PATH}/publishPactfiles.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/publish-provider-contract/action.yml
+++ b/publish-provider-contract/action.yml
@@ -47,7 +47,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/publishOAS.sh
+    - run: ${GITHUB_ACTION_PATH}/publishOAS.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/record-deployment/action.yml
+++ b/record-deployment/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/recordDeployment.sh
+    - run: ${GITHUB_ACTION_PATH}/recordDeployment.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 

--- a/record-release/action.yml
+++ b/record-release/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/recordRelease.sh
+    - run: ${GITHUB_ACTION_PATH}/recordRelease.sh
       shell: bash
       env: 
         PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 


### PR DESCRIPTION
Due to a bug in the GitHub Action Runner ([actions/runner#716](https://github.com/actions/runner/issues/716)), the `github.action_path` context does not resolve to a valid path in containers on self-hosted runners. In contrast, the `GITHUB_ACTION_PATH` environment variable always provides a valid path, even on self-hosted runners. This PR replaces references to `github.action_path` with `GITHUB_ACTION_PATH`.