### PR TITLE
Update comment in actions README to reflect new version default

### DIFF
--- a/can-i-deploy/action.yml
+++ b/can-i-deploy/action.yml
@@ -45,13 +45,13 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/canideployTo.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         to_environment: ${{ inputs.to_environment || env.to_environment }}
         to: ${{ inputs.to || env.to }}
         latest: ${{ inputs.latest }}

--- a/create-or-update-version/action.yml
+++ b/create-or-update-version/action.yml
@@ -27,11 +27,11 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/createOrUpdateVersion.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         branch: ${{ inputs.branch }}

--- a/create-version-tag/action.yml
+++ b/create-version-tag/action.yml
@@ -30,13 +30,13 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/createTag.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         tag: ${{ inputs.tag || env.tag }}
         tag_with_git_branch: ${{ inputs.tag_with_git_branch }}
         auto_create_version: ${{ inputs.auto_create_version }}

--- a/publish-pact-files/action.yml
+++ b/publish-pact-files/action.yml
@@ -19,7 +19,7 @@ inputs:
   version:
     description: "Version to publish"
   branch:
-    description: "branch to associate version of pact with"  
+    description: "branch to associate version of pact with"
   tag:
     description: "tag to associate version of pact with"
   tag_with_git_branch:
@@ -29,14 +29,13 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/publishPactfiles.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         pactfiles: ${{ inputs.pactfiles || env.pactfiles }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         tag: ${{ inputs.tag || env.tag }}
         branch: ${{ inputs.branch || env.branch }}
         tag_with_git_branch: ${{ inputs.tag_with_git_branch }}
-

--- a/publish-provider-contract/action.yml
+++ b/publish-provider-contract/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "Location of the contract file"
     required: true
   specification:
-      description: "The contract specification Default: oas"
+    description: "The contract specification Default: oas"
   contract_content_type:
     description: "The content type. eg. application/yml or application/json. defaults to application/yml"
   verification_exit_code:
@@ -35,7 +35,7 @@ inputs:
   verifier:
     description: "The tool used to verify the provider contract"
   verifier_version:
-    description: "The version of the tool used to verify the provider contract"  
+    description: "The version of the tool used to verify the provider contract"
   build_url:
     description: "The build URL that created the provider contract"
   version:
@@ -49,11 +49,11 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/publishOAS.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
         contract: ${{ inputs.contract || env.oas_file }}
         specification: ${{ inputs.specification }}
@@ -65,6 +65,6 @@ runs:
         verifier_version: ${{ inputs.verifier_version }}
         verifier: ${{ inputs.verifier || env.VERIFIER_TOOL }}
         build_url: ${{ inputs.build_url }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         branch: ${{ inputs.branch || env.branch }}
         tag: ${{ inputs.tag }}

--- a/record-deployment/action.yml
+++ b/record-deployment/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: "The name of the environment that the pacticipant version was deployed to"
     required: true
   version:
-    description: "The version of your application (defaults to version of the code where the action is run from)"  
+    description: "The version of your application (defaults to version of the code where the action is run from)"
   application_instance:
     description: "The application instance to which the deployment has occurred - a logical identifer required to differentiate deployments when there are multiple instances of the same application in an environment."
 runs:
@@ -28,12 +28,12 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/recordDeployment.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         environment: ${{ inputs.environment || env.environment }}
         application_instance: ${{ inputs.application_instance || env.application_instance }}

--- a/record-release/action.yml
+++ b/record-release/action.yml
@@ -20,18 +20,18 @@ inputs:
     description: "The name of the environment that the pacticipant version was released to"
     required: true
   version:
-    description: "The version of your application (defaults to version of the code where the action is run from)"  
+    description: "The version of your application (defaults to version of the code where the action is run from)"
 runs:
   using: "composite"
   steps:
     - run: ${GITHUB_ACTION_PATH}/recordRelease.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         application_name: ${{ inputs.application_name || env.application_name }}
-        version: ${{ inputs.version || env.version }}
+        version: ${{ inputs.version || env.version || github.sha }}
         environment: ${{ inputs.environment || env.environment }}
         application_instance: ${{ inputs.application_instance || env.application_instance }}


### PR DESCRIPTION
Update the comment in README files to reflect that the default value for `version`  
is taken from `env.version` instead of the git sha.