### PR TITLE
feat: allow custom pact cli image

### DIFF
--- a/can-i-deploy/action.yml
+++ b/can-i-deploy/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "check"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -50,6 +53,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         to_environment: ${{ inputs.to_environment || env.to_environment }}

--- a/can-i-deploy/canideployTo.sh
+++ b/can-i-deploy/canideployTo.sh
@@ -21,6 +21,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 COMMAND=
 if [ -z "$to" ] || [ -z "$to_environment" ]; then
   if [ -z "$to" ] && [ "$to_environment" ]; then
@@ -90,6 +98,7 @@ fi
 
 echo "
   PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
+  pact_cli_image: '$pact_cli_image'
   application_name: '$application_name'
   VERSION: '$VERSION'
   to: '$to'
@@ -101,7 +110,7 @@ docker run --rm \
   $PACT_BROKER_TOKEN_ENV_VAR_CMD \
   $PACT_BROKER_USERNAME_ENV_VAR_CMD \
   $PACT_BROKER_PASSWORD_ENV_VAR_CMD \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   broker can-i-deploy \
   --pacticipant "$application_name" \
   $VERSION \

--- a/create-or-update-version/action.yml
+++ b/create-or-update-version/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "check"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -32,6 +35,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         branch: ${{ inputs.branch }}

--- a/create-or-update-version/createOrUpdateVersion.sh
+++ b/create-or-update-version/createOrUpdateVersion.sh
@@ -10,6 +10,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 if [ "$version" == "" ]; then
   version=$(git rev-parse HEAD)
 fi
@@ -40,9 +48,9 @@ if [ "$PACT_BROKER_PASSWORD" ]; then
   PACT_BROKER_PASSWORD_ENV_VAR_CMD="-e PACT_BROKER_PASSWORD=$PACT_BROKER_PASSWORD"
 fi
 
-
 echo "
 PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
+pact_cli_image: '$pact_cli_image'
 version: '$version'
 application_name: '$application_name'
 branch: '$branch'
@@ -53,7 +61,7 @@ docker run --rm \
     $PACT_BROKER_TOKEN_ENV_VAR_CMD \
     $PACT_BROKER_USERNAME_ENV_VAR_CMD \
     $PACT_BROKER_PASSWORD_ENV_VAR_CMD \
-    pactfoundation/pact-cli:latest \
+    $PACT_CLI_IMAGE \
     broker create-or-update-version \
     --pacticipant "$application_name" \
     --version $version \

--- a/create-version-tag/action.yml
+++ b/create-version-tag/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "bookmark"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -35,6 +38,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         tag: ${{ inputs.tag || env.tag }}

--- a/create-version-tag/createTag.sh
+++ b/create-version-tag/createTag.sh
@@ -14,6 +14,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 AUTO_CREATE_VERSION_COMMAND=
 if [ "$auto_create_version" ]; then
   echo "You set auto_create_version"
@@ -30,6 +38,7 @@ fi
 
 echo """
 PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
+pact_cli_image: $pact_cli_image
 application_name: $application_name
 version: $version
 tag: $tag
@@ -60,7 +69,7 @@ docker run --rm \
   -e GITHUB_BASE_REF=$GITHUB_BASE_REF \
   -e GITHUB_REF=$GITHUB_REF \
   -e GITHUB_SHA=$GITHUB_SHA \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   broker create-version-tag \
   --pacticipant "$application_name" \
   --version "$version" \

--- a/delete-branch/action.yml
+++ b/delete-branch/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "check"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -26,7 +29,6 @@ inputs:
     options:
       - true
       - false
-
 runs:
   using: "composite"
   steps:
@@ -37,6 +39,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         branch: ${{ inputs.branch || env.branch }}

--- a/delete-branch/deleteBranch.sh
+++ b/delete-branch/deleteBranch.sh
@@ -12,6 +12,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 OPTIONS=
 if [ -n "${error_when_not_found}" ]; then
   if [ "${error_when_not_found}" = "true" ]; then
@@ -42,6 +50,7 @@ fi
 
 echo "
   PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
+  pact_cli_image: '$pact_cli_image'
   application_name: '$application_name'
   branch: '$branch'
   error_when_not_found: $error_when_not_found
@@ -53,7 +62,7 @@ docker run --rm \
   $PACT_BROKER_TOKEN_ENV_VAR_CMD \
   $PACT_BROKER_USERNAME_ENV_VAR_CMD \
   $PACT_BROKER_PASSWORD_ENV_VAR_CMD \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   broker delete-branch \
   --pacticipant "$application_name" \
   --branch "$branch" \

--- a/publish-pact-files/action.yml
+++ b/publish-pact-files/action.yml
@@ -10,6 +10,8 @@ inputs:
   pactfiles:
     description: "Location of the Pact files"
     required: true
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
   token:
     description: "Your pact broker token (required for PactFlow)"
   username:
@@ -19,7 +21,7 @@ inputs:
   version:
     description: "Version to publish"
   branch:
-    description: "branch to associate version of pact with"  
+    description: "branch to associate version of pact with"
   tag:
     description: "tag to associate version of pact with"
   tag_with_git_branch:
@@ -29,14 +31,14 @@ runs:
   steps:
     - run: ${GITHUB_ACTION_PATH}/publishPactfiles.sh
       shell: bash
-      env: 
-        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }} 
-        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
-        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
-        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+      env:
+        PACT_BROKER_BASE_URL: ${{ inputs.broker_url || env.PACT_BROKER_BASE_URL }}
+        PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }}
+        PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
+        PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         pactfiles: ${{ inputs.pactfiles || env.pactfiles }}
         version: ${{ inputs.version || env.version }}
         tag: ${{ inputs.tag || env.tag }}
         branch: ${{ inputs.branch || env.branch }}
         tag_with_git_branch: ${{ inputs.tag_with_git_branch }}
-

--- a/publish-pact-files/publishPactfiles.sh
+++ b/publish-pact-files/publishPactfiles.sh
@@ -14,12 +14,21 @@ build_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_I
 
 echo """
 PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
+pact_cli_image: $pact_cli_image
 version: $version
 pactfiles: $pactfiles
 branch: $branch
 build_url: $build_url
 tag: $tag
 """
+
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
 
 BRANCH_COMMAND=
 if [ "$branch" ]; then
@@ -72,7 +81,7 @@ docker run --rm \
   -e GITHUB_BASE_REF=$GITHUB_BASE_REF \
   -e GITHUB_REF=$GITHUB_REF \
   -e GITHUB_SHA=$GITHUB_SHA \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   publish \
   $pactfiles \
   --auto-detect-version-properties \

--- a/publish-provider-contract/action.yml
+++ b/publish-provider-contract/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "upload"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -54,6 +57,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         contract: ${{ inputs.contract || env.oas_file }}
         specification: ${{ inputs.specification }}

--- a/publish-provider-contract/publishOAS.sh
+++ b/publish-provider-contract/publishOAS.sh
@@ -16,6 +16,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 CONTRACT_FILE_CONTENT_TYPE=${contract_content_type:-"application/yml"}
 VERIFICATION_RESULTS_CONTENT_TYPE=${verification_results_content_type:-"text/plain"}
 SPECIFICATION=${specification:-"oas"}
@@ -46,9 +54,9 @@ if [ "$verifier_version" ]; then
   VERIFIER_VERSION_COMMAND="--verifier-version $verifier_version"
 fi
 
-
 echo """
 PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
+pact_cli_image: $pact_cli_image
 contract: $contract
 verification_results: $verification_results
 verification_exit_code: $verification_exit_code
@@ -61,7 +69,7 @@ docker run --rm \
   -v ${PWD}:${PWD} \
   -e PACT_BROKER_BASE_URL=$PACT_BROKER_BASE_URL \
   -e PACT_BROKER_TOKEN=$PACT_BROKER_TOKEN \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   pactflow publish-provider-contract \
   $contract \
   --provider $application_name \

--- a/record-deployment/action.yml
+++ b/record-deployment/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "check"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -33,6 +36,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         environment: ${{ inputs.environment || env.environment }}

--- a/record-deployment/recordDeployment.sh
+++ b/record-deployment/recordDeployment.sh
@@ -15,6 +15,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 APPLICATION_INSTANCE_COMMAND=
 if [ "$application_instance" ]; then
   echo "You set application_instance"
@@ -36,9 +44,9 @@ if [ "$PACT_BROKER_PASSWORD" ]; then
   PACT_BROKER_PASSWORD_ENV_VAR_CMD="-e PACT_BROKER_PASSWORD=$PACT_BROKER_PASSWORD"
 fi
 
-
 echo "
   PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
+  pact_cli_image: '$pact_cli_image'
   application_name: '$application_name'
   version: '$version'
   environment: '$environment'"
@@ -48,7 +56,7 @@ docker run --rm \
   $PACT_BROKER_TOKEN_ENV_VAR_CMD \
   $PACT_BROKER_USERNAME_ENV_VAR_CMD \
   $PACT_BROKER_PASSWORD_ENV_VAR_CMD \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   broker record-deployment \
   --pacticipant "$application_name" \
   --version $version \

--- a/record-release/action.yml
+++ b/record-release/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "check"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
@@ -31,6 +34,7 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.token || env.PACT_BROKER_TOKEN }} 
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }} 
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }} 
+        pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
         application_name: ${{ inputs.application_name || env.application_name }}
         version: ${{ inputs.version || env.version }}
         environment: ${{ inputs.environment || env.environment }}

--- a/record-release/recordRelease.sh
+++ b/record-release/recordRelease.sh
@@ -15,6 +15,14 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   exit 1
 fi
 
+PACT_CLI_IMAGE=
+if [ "$pact_cli_image" ]; then
+    echo "You set pact cli image"
+    PACT_CLI_IMAGE="$pact_cli_image"
+else
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+fi
+
 if [ "$PACT_BROKER_TOKEN" ]; then
   echo "You set token"
   PACT_BROKER_TOKEN_ENV_VAR_CMD="-e PACT_BROKER_TOKEN=$PACT_BROKER_TOKEN"
@@ -33,6 +41,7 @@ fi
 
 echo "
   PACT_BROKER_BASE_URL: '$PACT_BROKER_BASE_URL'
+  pact_cli_image: '$pact_cli_image'
   application_name: '$application_name'
   version: '$version'
   environment: '$environment'"
@@ -42,7 +51,7 @@ docker run --rm \
   $PACT_BROKER_TOKEN_ENV_VAR_CMD \
   $PACT_BROKER_USERNAME_ENV_VAR_CMD \
   $PACT_BROKER_PASSWORD_ENV_VAR_CMD \
-  pactfoundation/pact-cli:latest \
+  $PACT_CLI_IMAGE \
   broker record-release \
   --pacticipant "$application_name" \
   --version $version \


### PR DESCRIPTION
This PR adds the `pact_cli_image` input, allowing users to specify a custom Pact CLI image. This helps:
- Pin a specific image version.
- Use images from private registries.