### PR TITLE
refactor: split image and tag to align pact-publish-files with other …

### DIFF
--- a/publish-pact-files/action.yml
+++ b/publish-pact-files/action.yml
@@ -4,14 +4,18 @@ branding:
   icon: "upload"
   color: "green"
 inputs:
+  pact_cli_image:
+    description: "Docker image to use for running pact-cli commands (defaults to the official PactFlow image)"
+    required: false
+  pact_cli_image_tag:
+    description: "Tag of the Docker image to use for running pact-cli commands (default: latest)"
+    required: false
   broker_url:
     description: "The url of your pact broker"
     required: true
   pactfiles:
     description: "Location of the Pact files"
     required: true
-  pact_cli_image:
-    description: "Docker image to use for running pact-cli commands"
   token:
     description: "Your pact broker token (required for PactFlow)"
   username:
@@ -37,6 +41,7 @@ runs:
         PACT_BROKER_USERNAME: ${{ inputs.username || env.PACT_BROKER_USERNAME }}
         PACT_BROKER_PASSWORD: ${{ inputs.password || env.PACT_BROKER_PASSWORD }}
         pact_cli_image: ${{ inputs.pact_cli_image || env.pact_cli_image }}
+        pact_cli_image_tag: ${{ inputs.pact_cli_image_tag }}
         pactfiles: ${{ inputs.pactfiles || env.pactfiles }}
         version: ${{ inputs.version || env.version }}
         tag: ${{ inputs.tag || env.tag }}

--- a/publish-pact-files/publishPactfiles.sh
+++ b/publish-pact-files/publishPactfiles.sh
@@ -12,22 +12,14 @@ fi
 
 build_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-echo """
-PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
-pact_cli_image: $pact_cli_image
-version: $version
-pactfiles: $pactfiles
-branch: $branch
-build_url: $build_url
-tag: $tag
-"""
+PACT_CLI_IMAGE_TAG=${pact_cli_image_tag:-"latest"}
 
 PACT_CLI_IMAGE=
 if [ "$pact_cli_image" ]; then
-    echo "INFO: using user-specified CLI image: ${pact_cli_image}"
-    PACT_CLI_IMAGE="$pact_cli_image"
+    echo "INFO: using user-specified CLI image: ${pact_cli_image}:${PACT_CLI_IMAGE_TAG}"
+    PACT_CLI_IMAGE="${pact_cli_image}:${PACT_CLI_IMAGE_TAG}"
 else
-    PACT_CLI_IMAGE="pactfoundation/pact-cli:latest"
+    PACT_CLI_IMAGE="pactfoundation/pact-cli:${PACT_CLI_IMAGE_TAG}"
 fi
 
 BRANCH_COMMAND=
@@ -68,6 +60,15 @@ if [ "$PACT_BROKER_PASSWORD" ]; then
   PACT_BROKER_PASSWORD_ENV_VAR_CMD="-e PACT_BROKER_PASSWORD=$PACT_BROKER_PASSWORD"
 fi
 
+echo """
+PACT_BROKER_BASE_URL: $PACT_BROKER_BASE_URL
+pact_cli_image: $PACT_CLI_IMAGE
+version: $version
+pactfiles: $pactfiles
+branch: $branch
+build_url: $build_url
+tag: $tag
+"""
 
 
 docker run --rm \


### PR DESCRIPTION
This PR separates the image and tag definitions in the `pact-publish-files` GitHub Actions workflow to align its arguments with those in other actions. See [PR 75](https://github.com/pactflow/actions/pull/75)