### PR TITLE
fix: install the pact CLI on macOS again

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -15,7 +15,7 @@ if [ "$tag" ]; then
   PACT_CLI_VERSION="$tag"
 fi
 
-if [ -z "$PACT_CLI_VERSION"]; then
+if [ -z "$PACT_CLI_VERSION" ]; then
   PACT_CLI_VERSION=$(basename "$(curl -fs -o/dev/null -w "%{redirect_url}" https://github.com/pact-foundation/pact-standalone/releases/latest)")
   echo "Thanks for downloading the latest release of pact-standalone $PACT_CLI_VERSION."
   echo "-----"
@@ -47,14 +47,16 @@ case $(uname -sm) in
   if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
     os='osx'
   else
-    os='osx-arm64'
+    os='macos-arm64'
+    legacy_os='osx-arm64'
   fi
   ;;
 'Darwin x86' | 'Darwin x86_64')
   if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
     os='osx'
   else
-    os='osx-x86_64'
+    os='macos-x86_64'
+    legacy_os='osx-x86_64'
   fi
   ;;
 "Windows"* | "MINGW64"*)
@@ -75,20 +77,36 @@ case $os in
   filename="pact-${PACT_CLI_VERSION#v}-${os}.zip"
   ext=.bat
   ;;
-'osx'* | 'linux'*)
+'macos'* | 'osx'* | 'linux'*)
   filename="pact-${PACT_CLI_VERSION#v}-${os}.tar.gz"
   ;;
 esac
 
+if [ "$legacy_os" ]; then
+  legacy_filename="pact-${PACT_CLI_VERSION#v}-${legacy_os}.tar.gz"
+fi
+
+download_release_asset() {
+  curl -fsLO https://github.com/pact-foundation/pact-standalone/releases/download/"${PACT_CLI_VERSION}"/"$1"
+}
+
 echo "-------------"
 echo "Downloading:"
 echo "-------------"
-(curl -sLO https://github.com/pact-foundation/pact-standalone/releases/download/"${PACT_CLI_VERSION}"/"${filename}" && echo downloaded "${filename}") || (echo "Sorry, you'll need to install the pact-standalone manually." && exit 1)
+if download_release_asset "${filename}"; then
+  echo downloaded "${filename}"
+elif [ "$legacy_filename" ] && download_release_asset "${legacy_filename}"; then
+  filename="${legacy_filename}"
+  echo downloaded "${filename}"
+else
+  echo "Sorry, you'll need to install the pact-standalone manually."
+  exit 1
+fi
 case $os in
 'windows'* | 'win32')
   (unzip "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-standalone manually." && exit 1)
   ;;
-'osx'* | 'linux'*)
+'macos'* | 'osx'* | 'linux'*)
   (tar xzf "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-standalone manually." && exit 1)
   ;;
 esac


### PR DESCRIPTION
## Problem

The `Test pactflow/actions@main` workflow has been red on `main` since 2026-06-09 (first failing run [27182403367](https://github.com/pactflow/actions/actions/runs/27182403367); last green [26730383415](https://github.com/pactflow/actions/actions/runs/26730383415) on 2026-06-01). Only the `macos-latest` leg fails; `ubuntu-latest` and `windows-latest` pass.

## Root cause

`pact-foundation/pact-standalone` renamed its macOS release assets from `pact-<v>-osx-arm64.tar.gz` / `-osx-x86_64.tar.gz` to `pact-<v>-macos-arm64.tar.gz` / `-macos-x86_64.tar.gz`, starting with `v2.6.1` (released 2026-06-08). `v2.6.0` and earlier still carry the `osx-*` names.

`cli.sh` still asked for the `osx-*` name. Because the download used `curl -sLO` (no `-f`), GitHub's 404 body was written to disk as if it were the tarball, and the failure only surfaced one step later as:

```text
downloaded pact-2.6.4-osx-arm64.tar.gz
tar: Error opening archive: Unrecognized archive format
```

## Fix

- Request the current `macos-*` asset names on macOS, falling back to the legacy `osx-*` names so pinned versions at or below `v2.6.0` still install.
- Use `curl -f` so a missing asset fails at the download step with a clear message instead of producing an unreadable archive.
- Repair the `PACT_CLI_VERSION` pinning escape hatch. `[ -z "$PACT_CLI_VERSION"]` is missing a space, so with the variable set the test ran without its closing bracket and, under `sh -e`, aborted the script outright:

  ```text
  cli.sh: line 18: [: missing `]'
  ```

  That means the documented workaround for this bug did not actually work.

## Verification

Run on macOS arm64 against the modified script:

| scenario | result |
| --- | --- |
| unpinned (resolves `v2.6.4`) | `downloaded pact-2.6.4-macos-arm64.tar.gz` → installed, `pact-broker help` runs |
| `PACT_CLI_VERSION=v2.6.4` | `downloaded pact-2.6.4-macos-arm64.tar.gz` → installed |
| `PACT_CLI_VERSION=v2.5.12` (legacy naming) | falls back to `downloaded pact-2.5.12-osx-arm64.tar.gz` → installed |

`sh -n` passes and `shellcheck` reports no new findings (the three remaining warnings are pre-existing).

## Note

This is not the cause of the `test (18.x, …)` failures on the Renovate mocha PR (#93) — those are a separate `exit 127` from mocha 11 dropping the `bin/mocha` entry point, fixed on that branch directly.
